### PR TITLE
Update toucan-js to 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@sentry/integrations": "^7.28.1",
 				"@sentry/types": "^7.28.1",
 				"promjs": "^0.4.2",
-				"toucan-js": "^3.1.0",
+				"toucan-js": "^3.3.1",
 				"typescript": "5.0.4"
 			},
 			"devDependencies": {
@@ -1890,47 +1890,45 @@
 			}
 		},
 		"node_modules/@sentry/core": {
-			"version": "7.28.1",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.28.1.tgz",
-			"integrity": "sha512-7wvnuvn/mrAfcugWoCG/3pqDIrUgH5t+HisMJMGw0h9Tc33KqrmqMDCQVvjlrr2pWrw/vuUCFdm8CbUHJ832oQ==",
+			"version": "7.76.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.76.0.tgz",
+			"integrity": "sha512-M+ptkCTeCNf6fn7p2MmEb1Wd9/JXUWxIT/0QEc+t11DNR4FYy1ZP2O9Zb3Zp2XacO7ORrlL3Yc+VIfl5JTgjfw==",
 			"dependencies": {
-				"@sentry/types": "7.28.1",
-				"@sentry/utils": "7.28.1",
-				"tslib": "^1.9.3"
+				"@sentry/types": "7.76.0",
+				"@sentry/utils": "7.76.0"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/integrations": {
-			"version": "7.28.1",
-			"resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.28.1.tgz",
-			"integrity": "sha512-opeXVR1L9mZmZcpAs9kX+4JPY7pXhVupy17Sbz+43zd5CshYTveIcttGNPp+EPT3j7mMU+1TMAYZspKqJXtEBQ==",
+			"version": "7.76.0",
+			"resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.76.0.tgz",
+			"integrity": "sha512-4ea0PNZrGN9wKuE/8bBCRrxxw4Cq5T710y8rhdKHAlSUpbLqr/atRF53h8qH3Fi+ec0m38PB+MivKem9zUwlwA==",
 			"dependencies": {
-				"@sentry/types": "7.28.1",
-				"@sentry/utils": "7.28.1",
-				"localforage": "^1.8.1",
-				"tslib": "^1.9.3"
+				"@sentry/core": "7.76.0",
+				"@sentry/types": "7.76.0",
+				"@sentry/utils": "7.76.0",
+				"localforage": "^1.8.1"
 			},
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/types": {
-			"version": "7.28.1",
-			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.28.1.tgz",
-			"integrity": "sha512-DvSplMVrVEmOzR2M161V5+B8Up3vR71xMqJOpWTzE9TqtFJRGPtqT/5OBsNJJw1+/j2ssMcnKwbEo9Q2EGeS6g==",
+			"version": "7.76.0",
+			"resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.76.0.tgz",
+			"integrity": "sha512-vj6z+EAbVrKAXmJPxSv/clpwS9QjPqzkraMFk2hIdE/kii8s8kwnkBwTSpIrNc8GnzV3qYC4r3qD+BXDxAGPaw==",
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@sentry/utils": {
-			"version": "7.28.1",
-			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.28.1.tgz",
-			"integrity": "sha512-75/jzLUO9HH09iC9TslNimGbxOP3jgn89P+q7uR+rp2fJfRExHVeKJZQdK0Ij4/SmE7TJ3Uh2r154N0INZEx1g==",
+			"version": "7.76.0",
+			"resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.76.0.tgz",
+			"integrity": "sha512-40jFD+yfQaKpFYINghdhovzec4IEpB7aAuyH/GtE7E0gLpcqnC72r55krEIVILfqIR2Mlr5OKUzyeoCyWAU/yw==",
 			"dependencies": {
-				"@sentry/types": "7.28.1",
-				"tslib": "^1.9.3"
+				"@sentry/types": "7.76.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -7009,13 +7007,14 @@
 			}
 		},
 		"node_modules/toucan-js": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-3.1.0.tgz",
-			"integrity": "sha512-bRbq/HB+aSfwbsSoCNI6qyPXx2bhsscxSYxnAY63xXv9lIeOLUYfvYdOIBWfAVj9QHNST+X83GQ0lj/llvHpVg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/toucan-js/-/toucan-js-3.3.1.tgz",
+			"integrity": "sha512-9BpkHb/Pzsrtl1ItNq9OEQPnuUHwzce0nV2uG+DYFiQ4fPyiA6mKTBcDwQzcvNkfSER038U+8TzvdkCev+Maww==",
 			"dependencies": {
-				"@sentry/core": "7.28.1",
-				"@sentry/types": "7.28.1",
-				"@sentry/utils": "7.28.1"
+				"@sentry/core": "7.76.0",
+				"@sentry/integrations": "7.76.0",
+				"@sentry/types": "7.76.0",
+				"@sentry/utils": "7.76.0"
 			}
 		},
 		"node_modules/tr46": {
@@ -7069,7 +7068,9 @@
 		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@sentry/integrations": "^7.28.1",
 		"@sentry/types": "^7.28.1",
 		"promjs": "^0.4.2",
-		"toucan-js": "^3.1.0",
+		"toucan-js": "^3.3.1",
 		"typescript": "5.0.4"
 	}
 }

--- a/src/context/logging.ts
+++ b/src/context/logging.ts
@@ -1,6 +1,5 @@
 import type { Context } from 'toucan-js/dist/types';
-import { Toucan } from 'toucan-js';
-import { RewriteFrames } from '@sentry/integrations';
+import { RewriteFrames, Toucan } from 'toucan-js';
 import { Breadcrumb } from '@sentry/types';
 
 // End toucan-js types


### PR DESCRIPTION
toucan-js has been updated to 3.3.1, updating the underlying sentry libraries and types. This commit updates the library and its usage.